### PR TITLE
Issue #16 Get api and auth urls via headers

### DIFF
--- a/gulp/server.js
+++ b/gulp/server.js
@@ -31,17 +31,33 @@ function browserSyncInit(baseDir, browser) {
    *
    * For more details and option, https://github.com/chimurai/http-proxy-middleware/blob/v0.9.0/README.md
    */
-  server.middleware = proxyMiddleware('/api', {
-    target: 'https://api.cfp.io',
-    changeOrigin: true,
-    logLevel: 'debug',
-    onError(error, request, response) {
-      response.writeHead(500, {
-        'Content-Type': 'text/plain'
-      })
-      response.end('Something went wrong. And we are reporting a custom error message.')
-    }
-  })
+  server.middleware = [
+    (req, res, next) => {
+      if (req.url === '/infra') {
+        res.writeHead(200, {
+          'X-API-Server': 'https://api.cfp.io',
+          'X-Authentication-Server': 'https://auth.cfp.io'
+        })
+        res.end()
+      }
+      else {
+        next()
+      }
+    },
+
+    // Proxy not used anymore, we call the absolute url directly
+    proxyMiddleware('/api', {
+      target: 'https://api.cfp.io',
+      changeOrigin: true,
+      logLevel: 'debug',
+      onError(error, request, response) {
+        response.writeHead(500, {
+          'Content-Type': 'text/plain'
+        })
+        response.end('Something went wrong. And we are reporting a custom error message.')
+      }
+    })
+  ]
 
   browserSync.instance = browserSync.init({
     startPath: '/',

--- a/src/app/components/profile/form-profile.js
+++ b/src/app/components/profile/form-profile.js
@@ -1,19 +1,10 @@
 class FormProfileController {
-  constructor() {
+  constructor(Restangular) {
     'ngInject'
 
-    this.model = {
-      lastname: '',
-      firstname: '',
-      email: '',
-      favorite_language: '',
-      phone_number: '',
-      business: '',
-      bio: '',
-      twitter_profile: '',
-      google_profile: '',
-      github_profile: ''
-    }
+    Restangular.one('users/me').get().then((user) => {
+      this.model = user
+    })
   }
   onSubmit(event) {
     event.preventDefault()

--- a/src/app/components/security/auth.interceptor.js
+++ b/src/app/components/security/auth.interceptor.js
@@ -4,11 +4,8 @@ export const AuthenticationInterceptor = ($q, AuthenticationService) => {
   return {
     responseError(rejection) {
       if (rejection.status === 401) {
-        let authUrl = rejection.headers('Location')
-        if (authUrl) {
-          AuthenticationService.login(authUrl)
-          return // keep this!
-        }
+        AuthenticationService.login()
+        return // keep this!
       }
       return $q.reject(rejection)
     }

--- a/src/app/components/security/auth.service.js
+++ b/src/app/components/security/auth.service.js
@@ -9,8 +9,8 @@ export const AuthenticationService = () => {
     '$get': ($window, $location) => {
       'ngInject'
       return {
-        login: (url = authUrl) => {
-          $window.location = `${url}?target=${encodeURIComponent($location.absUrl())}`
+        login: () => {
+          $window.location = `${authUrl}?target=${encodeURIComponent($location.absUrl())}`
         },
         logout: () => {
           $window.location = `${authUrl}/logout`

--- a/src/app/index.config.js
+++ b/src/app/index.config.js
@@ -10,5 +10,5 @@ export const config = ($compileProvider, $logProvider, $translateProvider, Authe
 
   AuthenticationServiceProvider.authUrl(AppConfig.authServer)
 
-  RestangularProvider.setBaseUrl('/api')
+  RestangularProvider.setBaseUrl(AppConfig.apiServer + '/api')
 }

--- a/src/app/index.module.js
+++ b/src/app/index.module.js
@@ -27,10 +27,17 @@ const app = angular.module('io.cfp.front', [...dependencies, components.name])
     $log.debug('App Initialized')
   })
 
-const configLoaded = fetch('/api/application')
-  .then(response => response.json())
-  .then(appConfig => {
-    app.constant('AppConfig', appConfig)
+const configLoaded = fetch('/infra', {method: 'HEAD'})
+  .then(response => {
+    const config = {
+      apiServer :  response.headers.get('X-API-Server'),
+      authServer :  response.headers.get('X-Authentication-Server')
+    }
+    return fetch(config.apiServer + '/api/application')
+      .then(response => response.json())
+      .then(appConfig => {
+        app.constant('AppConfig', Object.assign(appConfig, config))
+      })
   })
 
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
J'ai ajouté le middleware pour recevoir les headers en dev (sur /infra pour le moment plutôt que api.json, je trouvais bizarre d'appeler un .json qui ne retourne pas de json...) et configuré l'appli pour utiliser les urls obtenues.

Par contre, j'ai ajouté un petit test sur la page de profile et j'ai toujours la même boucle sur localhost : 401 => redirection vers auth => déjà connecté => redirection vers la page de profile => 401.
Et maintenant la solution que j'avais décrite dans  la PR #15 ne fonctionne plus. Si je me met sur un autre host que localhost, je reçois une erreur lié à CORS : 
```
Fetch API cannot load https://api.cfp.io/api/application. No 'Access-Control-Allow-Origin' header is present on the requested resource. Origin 'http://dev-front.cfp.io:3002' is therefore not allowed access. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.
```